### PR TITLE
add select judgement outside the operator

### DIFF
--- a/src/main/java/com/sql/interpreter/Handler.java
+++ b/src/main/java/com/sql/interpreter/Handler.java
@@ -118,7 +118,8 @@ public class Handler {
             opLeft = new DuplicateEliminationOperator(opLeft);
         }
         else {
-            opLeft = new SortOperator(opLeft, plainSelect);
+            if(plainSelect.getOrderByElements() != null)
+                opLeft = new SortOperator(opLeft, plainSelect);
         }
         return opLeft;
     }


### PR DESCRIPTION
I pre-extract the expression before the constructor of selection operation, since sometimes we do not need such selection operator, and ```getWhere()``` fails to detect some cases.
e.g  
```Select * From S, R where R=3```  
After scaning S, we do not need to make a selection, but ```getWhere()``` is not null.